### PR TITLE
Use linuxdeploy to deploy dependencies for gstreamer plugins

### DIFF
--- a/linuxdeploy-plugin-gstreamer.sh
+++ b/linuxdeploy-plugin-gstreamer.sh
@@ -63,8 +63,8 @@ else
     plugins_dir=/usr/lib/$(uname -m)-linux-gnu/gstreamer-"$GSTREAMER_VERSION"
 fi
 
-if [ "$GSTREAMER_PLUGINS_DIR" != "" ]; then
-    helpers_dir="${GSTREAMER_PLUGINS_DIR}"
+if [ "$GSTREAMER_HELPERS_DIR" != "" ]; then
+    helpers_dir="${GSTREAMER_HELPERS_DIR}"
 else
     helpers_dir=/usr/lib/$(uname -m)-linux-gnu/gstreamer"$GSTREAMER_VERSION"/gstreamer-"$GSTREAMER_VERSION"
 fi

--- a/linuxdeploy-plugin-gstreamer.sh
+++ b/linuxdeploy-plugin-gstreamer.sh
@@ -14,11 +14,14 @@ show_usage() {
     echo
     echo "Bundles GStreamer plugins into an AppDir"
     echo
-    echo "Variables:"
-    echo "  GSTREAMER_INCLUDE_BAD_PLUGINS=\"1\" (optional; default: disabled; set to empty string or unset to disable)"
-    echo "  GSTREAMER_PLUGINS_DIR=\"...\" (optional; directory containing GStreamer plugins; default: guessed based on main distro architecture)"
-    echo "  GSTREAMER_HELPERS_DIR=\"...\" (optional; directory containing GStreamer helper tools like gst-plugin-scanner; default: guessed based on main distro architecture)"
-    echo "  GSTREAMER_VERSION=\"1.0\" (optional; default: 1.0)"
+    echo "Required variables:"
+    echo "  LINUXDEPLOY=\".../linuxdeploy\" path to linuxdeploy (e.g., AppImage); set automatically when plugin is run directly by linuxdeploy"
+    echo
+    echo "Optional variables:"
+    echo "  GSTREAMER_INCLUDE_BAD_PLUGINS=\"1\" (default: disabled; set to empty string or unset to disable)"
+    echo "  GSTREAMER_PLUGINS_DIR=\"...\" (directory containing GStreamer plugins; default: guessed based on main distro architecture)"
+    echo "  GSTREAMER_HELPERS_DIR=\"...\" (directory containing GStreamer helper tools like gst-plugin-scanner; default: guessed based on main distro architecture)"
+    echo "  GSTREAMER_VERSION=\"1.0\" (default: 1.0)"
 }
 
 while [ "$1" != "" ]; do
@@ -55,6 +58,13 @@ if ! which patchelf &>/dev/null && ! type patchelf &>/dev/null; then
     echo
     show_usage
     exit 2
+fi
+
+if [[ "$LINUXDEPLOY" == "" ]]; then
+    echo "Error: \$LINUXDEPLOY not set"
+    echo
+    show_usage
+    exit 3
 fi
 
 mkdir -p "$APPDIR"

--- a/linuxdeploy-plugin-gstreamer.sh
+++ b/linuxdeploy-plugin-gstreamer.sh
@@ -103,6 +103,13 @@ for i in "$helpers_dir"/*; do
     cp "$i" "$helpers_target_dir"
 done
 
+for i in "$helpers_target_dir"/*; do
+    [ -d "$i" ] && continue
+
+    patchelf --set-rpath '$ORIGIN/../..' $i
+    echo "Manually setting rpath for $i"
+done
+
 echo "Installing AppRun hook"
 mkdir -p "$APPDIR"/apprun-hooks
 
@@ -112,6 +119,7 @@ if [ "$GSTREAMER_VERSION" == "1.0" ]; then
 
 export GST_REGISTRY_REUSE_PLUGIN_SCANNER="no"
 export GST_PLUGIN_SYSTEM_PATH_1_0="${APPDIR}/usr/lib/gstreamer-1.0"
+export GST_PLUGIN_PATH_1_0="${APPDIR}/usr/lib/gstreamer-1.0"
 
 export GST_PLUGIN_SCANNER_1_0="${APPDIR}/usr/lib/gstreamer1.0/gstreamer-1.0/gst-plugin-scanner"
 export GST_PTP_HELPER_1_0="${APPDIR}/usr/lib/gstreamer1.0/gstreamer-1.0/gst-ptp-helper"

--- a/linuxdeploy-plugin-gstreamer.sh
+++ b/linuxdeploy-plugin-gstreamer.sh
@@ -50,6 +50,13 @@ if [ "$APPDIR" == "" ]; then
     exit 1
 fi
 
+if ! which patchelf &>/dev/null && ! type patchelf &>/dev/null; then
+    echo "Error: patchelf not found"
+    echo
+    show_usage
+    exit 2
+fi
+
 mkdir -p "$APPDIR"
 
 export GSTREAMER_VERSION=${GSTREAMER_VERSION:-1.0}

--- a/linuxdeploy-plugin-gstreamer.sh
+++ b/linuxdeploy-plugin-gstreamer.sh
@@ -69,7 +69,7 @@ fi
 
 mkdir -p "$APPDIR"
 
-export GSTREAMER_VERSION=${GSTREAMER_VERSION:-1.0}
+export GSTREAMER_VERSION="${GSTREAMER_VERSION:-1.0}"
 
 plugins_target_dir="$APPDIR"/usr/lib/gstreamer-"$GSTREAMER_VERSION"
 helpers_target_dir="$APPDIR"/usr/lib/gstreamer"$GSTREAMER_VERSION"/gstreamer-"$GSTREAMER_VERSION"
@@ -101,13 +101,13 @@ for i in "$plugins_dir"/*; do
     cp "$i" "$plugins_target_dir"
 done
 
-$LINUXDEPLOY --appdir $APPDIR
+"$LINUXDEPLOY" --appdir "$APPDIR"
 
 for i in "$plugins_target_dir"/*; do
     [ -d "$i" ] && continue
 
-    patchelf --set-rpath '$ORIGIN/..:$ORIGIN' $i
     echo "Manually setting rpath for $i"
+    patchelf --set-rpath '$ORIGIN/..:$ORIGIN' "$i"
 done
 
 mkdir -p "$helpers_target_dir"
@@ -123,8 +123,8 @@ done
 for i in "$helpers_target_dir"/*; do
     [ -d "$i" ] && continue
 
-    patchelf --set-rpath '$ORIGIN/../..' $i
     echo "Manually setting rpath for $i"
+    patchelf --set-rpath '$ORIGIN/../..' "$i"
 done
 
 echo "Installing AppRun hook"

--- a/linuxdeploy-plugin-gstreamer.sh
+++ b/linuxdeploy-plugin-gstreamer.sh
@@ -84,6 +84,15 @@ for i in "$plugins_dir"/*; do
     cp "$i" "$plugins_target_dir"
 done
 
+$LINUXDEPLOY --appdir $APPDIR
+
+for i in "$plugins_target_dir"/*; do
+    [ -d "$i" ] && continue
+
+    patchelf --set-rpath '$ORIGIN/..:$ORIGIN' $i
+    echo "Manually setting rpath for $i"
+done
+
 mkdir -p "$helpers_target_dir"
 
 echo "Copying helpers in $helpers_target_dir"


### PR DESCRIPTION
**The current problem**
When I was trying to use this plugin to pack gstreamer plugins into my AppImage I got into some troubles. Current implementation just copies all plugins to `usr/lib/gstreamer-1.0` folder, however, some plugins can have additional dependencies which are not listed in the executable itself.

**The first approach to solve it**
Rather straightforward approach is to use linuxdeploy again inside the plugin. I've found that `$LINUXDEPLOY` environment variable is accessible in plugin. So after plugins are copied to appropriate folder I'm running something like this.
`$LINUXDEPLOY --appdir $APPDIR`
This method is good enough - it deploys all dependencies for plugins but still one issue exists: rpath is not set correctly. It's specified as `$ORIGIN` while it should point to one directory lower (`$ORIGIN/..`).

**Second attempt**
Another possible solution could be to deploy dependencies only for gstreamer plugins. Plugins still should be copied in advance. It could be done like this:
```
gstreamer_plugins=""
for i in "$plugins_target_dir"/*; do
    [ -d "$i" ] && continue

    gstreamer_plugins+="--deploy-deps-only=$i "
done

$LINUXDEPLOY --appdir $APPDIR $gstreamer_plugins
```
However, the problem is that firtsly linuxdeploy executes `deployDependenciesForExistingFiles` and after that it executes `deployDependenciesOnlyForElfFile`. Basically it means that it `deployDependenciesOnlyForElfFile` sets the correct rpath (`$ORIGIN/..`) while `deployDependenciesForExistingFiles` overwrites it with `$ORIGIN` rpath.

**Third attempt**
Probably we could rid of manual copying and use `-l` flag to deploy the library with its dependencies. 
```
gstreamer_plugins=""
for i in "$plugins_dir"/*; do
    [ -d "$i" ] && continue

    gstreamer_plugins+="-l $i "
done

$LINUXDEPLOY --appdir $APPDIR $gstreamer_plugins
```
The problem is that it will copy all plugins in `usr/lib` instead of `usr/lib/gstreamer-1.0` and moreover the issue with `$ORIGIN` rpath will remain.

**Final solution**
To tell the truth, each of this attempt can be fixed by patching linuxdeploy tool but I decided not to do it for personal use. The first attempt was almost perfect apart from rpath issue, so I've tuned it a little bit:
```
$LINUXDEPLOY --appdir $APPDIR

for i in "$plugins_target_dir"/*; do
    [ -d "$i" ] && continue

    patchelf --set-rpath '$ORIGIN/..:$ORIGIN' $i
    echo "Manually setting rpath for $i"
done
```
This means that after linuxdeploy execution I'm setting correct rpath manually to all this files.

**More generalized approach (based on first attempt)**
Probably this approach will give more benefit but it requires linuxdeploy patching. In method `deployDependenciesForExistingFiles` for shared libraries we're always using `$ORIGIN` rpath which implies that all dependencies for libraries are placed in `usr/lib`. However, as I stated at the beginning there could be situation when some libs are placed in different folder (`gstreamer-1.0` in our case) but are still using dependencies from `usr/lib`. So the solution would be to change rpath calculation a little.
```
for (const auto& sharedLibrary : listSharedLibraries()) {
    if (bf::is_symlink(sharedLibrary))
        continue;

    if (!d->deployElfDependencies(sharedLibrary))
        return false;

    std::string rpath = "$ORIGIN";

    auto libraryDir = bf::absolute(d->appDirPath) / "usr" /
                      PrivateData::getLibraryDirName(sharedLibrary);
    if (sharedLibrary.parent_path() != libraryDir) {
      rpath = PrivateData::calculateRelativeRPath(libraryDir,
                                                  sharedLibrary.parent_path());
    }

    d->setElfRPathOperations[sharedLibrary] = rpath;
}
```
Actually, it's just a possible fix, so I haven't tested it properly due to my decision to stay in `*-plugin-*.sh` domain. If you like the above mentioned solution we could implement it in linuxdeploy tool otherwise this PR has already fixed my issues for gstreamer.