### PR TITLE
Check if file exist or if it's a format

### DIFF
--- a/linuxdeploy-plugin-gstreamer.sh
+++ b/linuxdeploy-plugin-gstreamer.sh
@@ -96,6 +96,7 @@ mkdir -p "$plugins_target_dir"
 echo "Copying plugins into $plugins_target_dir"
 for i in "$plugins_dir"/*; do
     [ -d "$i" ] && continue
+    [ ! -f "$i" ] && echo "File does not exist: $i" && continue
 
     echo "Copying plugin: $i"
     cp "$i" "$plugins_target_dir"
@@ -105,6 +106,7 @@ done
 
 for i in "$plugins_target_dir"/*; do
     [ -d "$i" ] && continue
+    [ ! -f "$i" ] && echo "File does not exist: $i" && continue
 
     echo "Manually setting rpath for $i"
     patchelf --set-rpath '$ORIGIN/..:$ORIGIN' "$i"
@@ -115,6 +117,7 @@ mkdir -p "$helpers_target_dir"
 echo "Copying helpers in $helpers_target_dir"
 for i in "$helpers_dir"/*; do
     [ -d "$i" ] && continue
+    [ ! -f "$i" ] && echo "File does not exist: $i" && continue
 
     echo "Copying helper: $i"
     cp "$i" "$helpers_target_dir"
@@ -122,6 +125,7 @@ done
 
 for i in "$helpers_target_dir"/*; do
     [ -d "$i" ] && continue
+    [ ! -f "$i" ] && echo "File does not exist: $i" && continue
 
     echo "Manually setting rpath for $i"
     patchelf --set-rpath '$ORIGIN/../..' "$i"

--- a/linuxdeploy-plugin-gstreamer.sh
+++ b/linuxdeploy-plugin-gstreamer.sh
@@ -107,6 +107,7 @@ done
 for i in "$plugins_target_dir"/*; do
     [ -d "$i" ] && continue
     [ ! -f "$i" ] && echo "File does not exist: $i" && continue
+    "$(file "$i" | grep -v ELF --silent)" && echo "Ignoring non ELF file: $i" && continue
 
     echo "Manually setting rpath for $i"
     patchelf --set-rpath '$ORIGIN/..:$ORIGIN' "$i"
@@ -126,6 +127,7 @@ done
 for i in "$helpers_target_dir"/*; do
     [ -d "$i" ] && continue
     [ ! -f "$i" ] && echo "File does not exist: $i" && continue
+    "$(file "$i" | grep -v ELF --silent)" && echo "Ignoring non ELF file: $i" && continue
 
     echo "Manually setting rpath for $i"
     patchelf --set-rpath '$ORIGIN/../..' "$i"


### PR DESCRIPTION
script fails if path does not exist  or file isn't an ELF file.
some gstreamer plugins can be python scripts, resulting in a patchelf failure.