### PR TITLE
Fix non-elf file skip

### DIFF
--- a/linuxdeploy-plugin-gstreamer.sh
+++ b/linuxdeploy-plugin-gstreamer.sh
@@ -107,7 +107,7 @@ done
 for i in "$plugins_target_dir"/*; do
     [ -d "$i" ] && continue
     [ ! -f "$i" ] && echo "File does not exist: $i" && continue
-    "$(file "$i" | grep -v ELF --silent)" && echo "Ignoring non ELF file: $i" && continue
+    $(file "$i" | grep -v ELF --silent) && echo "Ignoring non ELF file: $i" && continue
 
     echo "Manually setting rpath for $i"
     patchelf --set-rpath '$ORIGIN/..:$ORIGIN' "$i"
@@ -127,7 +127,7 @@ done
 for i in "$helpers_target_dir"/*; do
     [ -d "$i" ] && continue
     [ ! -f "$i" ] && echo "File does not exist: $i" && continue
-    "$(file "$i" | grep -v ELF --silent)" && echo "Ignoring non ELF file: $i" && continue
+    $(file "$i" | grep -v ELF --silent) && echo "Ignoring non ELF file: $i" && continue
 
     echo "Manually setting rpath for $i"
     patchelf --set-rpath '$ORIGIN/../..' "$i"


### PR DESCRIPTION
After I did more research on #5 it turned out that the check was wrong.
As it was stated in the issue #5, $(...) should return `0` in case of ELF file and `1` otherwise. However, turning a boolean `$(...)` into a string `"$(...)"` breaks this condition.