### PR TITLE
add support for 32&64 bit gstreamer and different linux distribution

### DIFF
--- a/linuxdeploy-plugin-gstreamer.sh
+++ b/linuxdeploy-plugin-gstreamer.sh
@@ -107,7 +107,7 @@ done
 for i in "$plugins_target_dir"/*; do
     [ -d "$i" ] && continue
     [ ! -f "$i" ] && echo "File does not exist: $i" && continue
-    $(file "$i" | grep -v ELF --silent) && echo "Ignoring non ELF file: $i" && continue
+    (file "$i" | grep -v ELF --silent) && echo "Ignoring non ELF file: $i" && continue
 
     echo "Manually setting rpath for $i"
     patchelf --set-rpath '$ORIGIN/..:$ORIGIN' "$i"

--- a/linuxdeploy-plugin-gstreamer.sh
+++ b/linuxdeploy-plugin-gstreamer.sh
@@ -75,15 +75,15 @@ if [ "$GSTREAMER_PLUGINS_DIR" != "" ]; then
     plugins_dir="${GSTREAMER_PLUGINS_DIR}"
 else
     for i in "/lib" "/usr/lib"; do
-        if [ -d $i/$(uname -m)-linux-gnu/gstreamer-"$GSTREAMER_VERSION" ]; then
+        if [ -d "$i/$(uname -m)-linux-gnu/gstreamer-$GSTREAMER_VERSION" ]; then
 	    plugins_dir=$i/$(uname -m)-linux-gnu/gstreamer-"$GSTREAMER_VERSION"
         elif [ -d $i/gstreamer-"$GSTREAMER_VERSION" ]; then
 	    plugins_dir=$i/gstreamer-"$GSTREAMER_VERSION"
 	fi
     done
-    if [ -z $plugins_dir ]; then
+    if [ -z "$plugins_dir" ]; then
 	for i in "/lib$(getconf LONG_BIT)" "/usr/lib$(getconf LONG_BIT)"; do
-            [ -d $i/gstreamer-"$GSTREAMER_VERSION" ] && plugins_dir=$i/gstreamer-"$GSTREAMER_VERSION"
+            [ -d "$i/gstreamer-$GSTREAMER_VERSION" ] && plugins_dir=$i/gstreamer-"$GSTREAMER_VERSION"
         done
     fi
 fi
@@ -92,7 +92,7 @@ if [ ! -d "$plugins_dir" ]; then
     echo "Error: could not find plugins directory: $plugins_dir"
     exit 1
 else
-    plugins_dir=$(readlink -f $plugins_dir)
+    plugins_dir=$(readlink -f "$plugins_dir")
 fi
 
 if [ "$GSTREAMER_HELPERS_DIR" != "" ]; then

--- a/linuxdeploy-plugin-gstreamer.sh
+++ b/linuxdeploy-plugin-gstreamer.sh
@@ -140,7 +140,7 @@ helpers_target_dir="$APPDIR"/${helpers_dir#"/"}
 
 mkdir -p "$plugins_target_dir"
 
-[ ! "$plugins_dir" = "$helpers_dir" ] && echo "Copying plugins into $plugins_target_dir"
+[ "$plugins_dir" != "$helpers_dir" ] && echo "Copying plugins into $plugins_target_dir"
 [ "$plugins_dir" = "$helpers_dir" ] && echo "Copying plugins and helpers into $plugins_target_dir"
 for i in "$plugins_dir"/*; do
     [ -d "$i" ] && continue
@@ -162,7 +162,7 @@ for i in "$plugins_target_dir"/*; do
 done
 
 # $helpers_dir may be empty if helpers not found and $GSTREAMER_HELPERS_DIR not set in previous steps.
-if [ -n "$helpers_dir" ] && [ ! "$helpers_dir" = "$plugins_dir" ]; then
+if [ -n "$helpers_dir" ] && [ "$helpers_dir" != "$plugins_dir" ]; then
     mkdir -p "$helpers_target_dir"
 
     echo "Copying helpers in $helpers_target_dir"

--- a/linuxdeploy-plugin-gstreamer.sh
+++ b/linuxdeploy-plugin-gstreamer.sh
@@ -72,6 +72,7 @@ mkdir -p "$APPDIR"
 export GSTREAMER_VERSION="${GSTREAMER_VERSION:-1.0}"
 
 if [ "$GSTREAMER_PLUGINS_DIR" != "" ]; then
+    # remove additional slash"/", to prevent duplicate slash output in AppRun-hook
     plugins_dir="${GSTREAMER_PLUGINS_DIR%"/"}"
 else
     for i in "/lib" "/usr/lib"; do
@@ -81,13 +82,21 @@ else
 	    plugins_dir=$i/gstreamer-"$GSTREAMER_VERSION"
 	fi
     done
+    # if not found gstreamer plugin directory in /lib and /usr/lib,
+    # try to find it in /lib32 and /usr/lib32(if using 32-bit linux), or /lib64 and /usr/lib64(if using 64-bit linux)
     if [ ! -d "$plugins_dir" ]; then
+        # as far as I know, $(getconf LONG_BIT) indicates the default C compiling environment is 32 or 64 bit.
+	# it is usually the same with kernel, but not always. I only tested in archlinux distro.
+	# in this case, due to gstreamer is a C program,
+	# if $(getconf LONG_BIT) output "32", we assume the default gstreamer is 32-bit version.
 	for i in "/lib$(getconf LONG_BIT)" "/usr/lib$(getconf LONG_BIT)"; do
             [ -d "$i/gstreamer-$GSTREAMER_VERSION" ] && plugins_dir=$i/gstreamer-"$GSTREAMER_VERSION"
         done
     fi
 fi
 
+# /lib /usr/lib /lib32 /lib64 ... may be a symlink,
+# convert to the realpath to keep the same structure between AppDir and local system.
 plugins_dir=$(readlink -f "$plugins_dir")
 if [ ! -d "$plugins_dir" ]; then
     echo "Error: could not find plugins directory: $plugins_dir"
@@ -95,6 +104,7 @@ if [ ! -d "$plugins_dir" ]; then
 fi
 
 if [ "$GSTREAMER_HELPERS_DIR" != "" ]; then
+    # remove additional slash"/", to prevent duplicate slash output in AppRun-hook
     helpers_dir="${GSTREAMER_HELPERS_DIR%"/"}"
 else
     if [ -f "$plugins_dir/gstreamer-$GSTREAMER_VERSION/gst-plugin-scanner" ]; then
@@ -104,15 +114,27 @@ else
     else
         echo "Error: could not find gst-plugin-scanner"
         echo "Error: failed to locate gstreamer helpers directory automatically"
-        echo "Error: please consider to specify \$GSTREAMER_HELPERS_DIR"
+        echo "Error: please consider specifing \$GSTREAMER_HELPERS_DIR"
     fi
 fi
 
+# path may include symlink directory,
+# convert to the realpath to keep the same structure between AppDir and local system.
 helpers_dir=$(readlink -f "$helpers_dir")
 if [ ! -d "$helpers_dir" ]; then
     echo "Error: could not find helpers directory: $helpers_dir"
+    # in the original project, the process will exit if plugins_dir is not found,
+    # but still process if only the helpers is not found.
+    # I am not sure if this is correct, so I keep the same setting at this moment.
+    #exit 1
 fi
 
+# below three statements are the same thing:
+# "$APPDIR""$plugins_dir"
+# "$APPDIR"/${plugins_dir#/}
+# "$APPDIR"/${plugins_dir#"/"}
+# I choose the third one because it can let me easily know the directory is under AppDir.
+# same reason below when output the apprun-hook.
 plugins_target_dir="$APPDIR"/${plugins_dir#"/"}
 helpers_target_dir="$APPDIR"/${helpers_dir#"/"}
 
@@ -139,6 +161,7 @@ for i in "$plugins_target_dir"/*; do
     patchelf --set-rpath '$ORIGIN/..:$ORIGIN' "$i"
 done
 
+# $helpers_dir may be empty if helpers not found and $GSTREAMER_HELPERS_DIR not set in previous steps.
 if [ -n "$helpers_dir" ] && [ ! "$helpers_dir" = "$plugins_dir" ]; then
     mkdir -p "$helpers_target_dir"
 

--- a/linuxdeploy-plugin-gstreamer.sh
+++ b/linuxdeploy-plugin-gstreamer.sh
@@ -127,7 +127,7 @@ done
 for i in "$helpers_target_dir"/*; do
     [ -d "$i" ] && continue
     [ ! -f "$i" ] && echo "File does not exist: $i" && continue
-    $(file "$i" | grep -v ELF --silent) && echo "Ignoring non ELF file: $i" && continue
+    (file "$i" | grep -v ELF --silent) && echo "Ignoring non ELF file: $i" && continue
 
     echo "Manually setting rpath for $i"
     patchelf --set-rpath '$ORIGIN/../..' "$i"

--- a/linuxdeploy-plugin-gstreamer.sh
+++ b/linuxdeploy-plugin-gstreamer.sh
@@ -107,7 +107,7 @@ done
 for i in "$plugins_target_dir"/*; do
     [ -d "$i" ] && continue
     [ ! -f "$i" ] && echo "File does not exist: $i" && continue
-    "$(file "$i" | grep -v ELF --silent)" && echo "Ignoring non ELF file: $i" && continue
+    $(file "$i" | grep -v ELF --silent) && echo "Ignoring non ELF file: $i" && continue
 
     echo "Manually setting rpath for $i"
     patchelf --set-rpath '$ORIGIN/..:$ORIGIN' "$i"
@@ -127,7 +127,7 @@ done
 for i in "$helpers_target_dir"/*; do
     [ -d "$i" ] && continue
     [ ! -f "$i" ] && echo "File does not exist: $i" && continue
-    "$(file "$i" | grep -v ELF --silent)" && echo "Ignoring non ELF file: $i" && continue
+    $(file "$i" | grep -v ELF --silent) && echo "Ignoring non ELF file: $i" && continue
 
     echo "Manually setting rpath for $i"
     patchelf --set-rpath '$ORIGIN/../..' "$i"

--- a/linuxdeploy-plugin-gstreamer.sh
+++ b/linuxdeploy-plugin-gstreamer.sh
@@ -155,7 +155,7 @@ if [ "$GSTREAMER_VERSION" == "1.0" ]; then
 
 export GST_REGISTRY_REUSE_PLUGIN_SCANNER="no"
 export GST_PLUGIN_SYSTEM_PATH_1_0="\${APPDIR}/${plugins_dir#"/"}"
-export GST_PLUGIN_PATH_1_0="\${APPDIR}/usr/${plugins_dir#"/"}"
+export GST_PLUGIN_PATH_1_0="\${APPDIR}/${plugins_dir#"/"}"
 
 export GST_PLUGIN_SCANNER_1_0="\${APPDIR}/${helpers_dir#"/"}/gst-plugin-scanner"
 export GST_PTP_HELPER_1_0="\${APPDIR}/${helpers_dir#"/"}/gst-ptp-helper"

--- a/linuxdeploy-plugin-gstreamer.sh
+++ b/linuxdeploy-plugin-gstreamer.sh
@@ -72,7 +72,7 @@ mkdir -p "$APPDIR"
 export GSTREAMER_VERSION="${GSTREAMER_VERSION:-1.0}"
 
 if [ "$GSTREAMER_PLUGINS_DIR" != "" ]; then
-    plugins_dir="${GSTREAMER_PLUGINS_DIR}"
+    plugins_dir="${GSTREAMER_PLUGINS_DIR%"/"}"
 else
     for i in "/lib" "/usr/lib"; do
         if [ -d "$i/$(uname -m)-linux-gnu/gstreamer-$GSTREAMER_VERSION" ]; then
@@ -96,7 +96,7 @@ else
 fi
 
 if [ "$GSTREAMER_HELPERS_DIR" != "" ]; then
-    helpers_dir="${GSTREAMER_HELPERS_DIR}"
+    helpers_dir="${GSTREAMER_HELPERS_DIR%"/"}"
 else
     helpers_dir=$plugins_dir/gstreamer-"$GSTREAMER_VERSION"
 fi

--- a/linuxdeploy-plugin-gstreamer.sh
+++ b/linuxdeploy-plugin-gstreamer.sh
@@ -81,7 +81,7 @@ else
 	    plugins_dir=$i/gstreamer-"$GSTREAMER_VERSION"
 	fi
     done
-    if [ -z "$plugins_dir" ]; then
+    if [ ! -d "$plugins_dir" ]; then
 	for i in "/lib$(getconf LONG_BIT)" "/usr/lib$(getconf LONG_BIT)"; do
             [ -d "$i/gstreamer-$GSTREAMER_VERSION" ] && plugins_dir=$i/gstreamer-"$GSTREAMER_VERSION"
         done


### PR DESCRIPTION
Add support for 32&64 bit gstreamer due to the current version only copy 32-bit and 64-bit plugins in the same place.
Add support for different linux distribution due to different library path in different distribution. I did not add option to specify the `$plugins_target_dir`, only keep the same structure between `/` and `$APPDIR`. If necessary to add option to specify the `$plugins_target_dir`, please tell me, thanks.